### PR TITLE
[Fix] Security policy and signature

### DIFF
--- a/FPPicker.podspec
+++ b/FPPicker.podspec
@@ -57,7 +57,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'AFNetworking', '~> 2.6.0'
   s.ios.dependency 'MBProgressHUD', '~> 0.9'
-  s.osx.dependency 'PureLayout', '~> 2.0.6'
 
   s.requires_arc = true
 

--- a/FPPicker/Shared/FPConfig.h
+++ b/FPPicker/Shared/FPConfig.h
@@ -23,10 +23,9 @@ typedef void (^FPImageUploadPreprocessorBlock)(NSURL *localURL, NSString *mimety
  */
 @property (nonatomic, strong) NSString *APIKey;
 
-/*!
-   Filepicker.io App secret key (required if security is enabled in Developer Portal)
- */
-@property (nonatomic, strong) NSString *appSecretKey;
+@property (nonatomic, strong) NSString *appSecurityPolicy;
+
+@property (nonatomic, strong) NSString *appSecuritySignature;
 
 /*!
    Indicates that the file should be stored in a way that allows public access

--- a/FPPicker/Shared/FPPrivateConfig.h
+++ b/FPPicker/Shared/FPPrivateConfig.h
@@ -17,7 +17,8 @@
 
 #define fpCOOKIES                   [[FPConfig sharedInstance] cookies]
 #define fpAPIKEY                    [[FPConfig sharedInstance] APIKey]
-#define fpAPPSECRETKEY              [[FPConfig sharedInstance] appSecretKey]
+#define fpAPPSECURITYPOLICY         [[FPConfig sharedInstance] appSecurityPolicy]
+#define fpAPPSECURITYSIGNATURE      [[FPConfig sharedInstance] appSecuritySignature]
 
 #define fpWindowSize                CGSizeMake(320, 480)
 #define fpCellIdentifier            @"Filepicker_Cell"

--- a/FPPicker/Shared/FPSession+ConvenienceMethods.m
+++ b/FPPicker/Shared/FPSession+ConvenienceMethods.m
@@ -26,10 +26,9 @@
 
 - (void)populateSecurityPropertiesFromConfig
 {
-    if (fpAPPSECURITYPOLICY)
+    if (fpAPPSECURITYPOLICY && fpAPPSECURITYSIGNATURE)
     {
         NSString *securityPolicy = fpAPPSECURITYPOLICY;
-
         NSString *securitySignature = fpAPPSECURITYSIGNATURE;
         self.securityPolicy = securityPolicy;
         self.securitySignature = securitySignature;

--- a/FPPicker/Shared/FPSession+ConvenienceMethods.m
+++ b/FPPicker/Shared/FPSession+ConvenienceMethods.m
@@ -26,15 +26,11 @@
 
 - (void)populateSecurityPropertiesFromConfig
 {
-    if (fpAPPSECRETKEY)
+    if (fpAPPSECURITYPOLICY)
     {
-        NSString *securityPolicy = [FPUtils policyForHandle:nil
-                                             expiryInterval:3600.0
-                                             andCallOptions:nil];
+        NSString *securityPolicy = fpAPPSECURITYPOLICY;
 
-        NSString *securitySignature = [FPUtils signPolicy:securityPolicy
-                                                 usingKey:fpAPPSECRETKEY];
-
+        NSString *securitySignature = fpAPPSECURITYSIGNATURE;
         self.securityPolicy = securityPolicy;
         self.securitySignature = securitySignature;
     }

--- a/FPPicker/Shared/FPUtils.m
+++ b/FPPicker/Shared/FPUtils.m
@@ -207,7 +207,7 @@
 
 + (NSString *)filePickerLocationWithOptionalSecurityFor:(NSString *)filePickerLocation
 {
-    if (fpAPPSECURITYPOLICY)
+    if (fpAPPSECURITYPOLICY && fpAPPSECURITYSIGNATURE)
     {
         NSString *handle = [[NSURL URLWithString:filePickerLocation] lastPathComponent];
 

--- a/FPPicker/Shared/FPUtils.m
+++ b/FPPicker/Shared/FPUtils.m
@@ -207,7 +207,7 @@
 
 + (NSString *)filePickerLocationWithOptionalSecurityFor:(NSString *)filePickerLocation
 {
-    if (fpAPPSECRETKEY)
+    if (fpAPPSECURITYPOLICY)
     {
         NSString *handle = [[NSURL URLWithString:filePickerLocation] lastPathComponent];
 
@@ -215,12 +215,9 @@
                  @"Failed to extract handle from %@",
                  filePickerLocation);
 
-        NSString *policy = [self policyForHandle:handle
-                                  expiryInterval:3600.0
-                                  andCallOptions:@[@"read"]];
+        NSString *policy = fpAPPSECURITYPOLICY;
 
-        NSString *signature = [self signPolicy:policy
-                                      usingKey:fpAPPSECRETKEY];
+        NSString *signature = fpAPPSECURITYSIGNATURE;
 
         NSString *queryString = [NSString stringWithFormat:@"?policy=%@&signature=%@",
                                  policy,

--- a/Podfile
+++ b/Podfile
@@ -21,5 +21,5 @@ end
 target :'FPPickerMac' do
   platform :osx, '10.9'
   pod 'AFNetworking', '~> 2.6.0'
-  pod 'PureLayout', '~> 2.0.6'
+#  pod 'PureLayout', '~> 2.0.6' # Commented due to dependency conflict with the pods of Kaizena iOS
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,20 +25,17 @@ PODS:
   - OHHTTPStubs (3.1.12):
     - OHHTTPStubs/Core (= 3.1.12)
   - OHHTTPStubs/Core (3.1.12)
-  - PureLayout (2.0.6)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.6.0)
   - MBProgressHUD (~> 0.9)
   - OCMock (~> 3.0.2)
   - OHHTTPStubs (~> 3.1.2)
-  - PureLayout (~> 2.0.6)
 
 SPEC CHECKSUMS:
   AFNetworking: 79f7eb1a0fcfa7beb409332b2ca49afe9ce53b05
   MBProgressHUD: c47f2c166c126cf2ce36498d80f33e754d4e93ad
   OCMock: 1f0871af0f397183f33e7552cca088bd2b485c25
   OHHTTPStubs: 8cf0cfe6f34f13fc88fdf5b2a1b2c2536e8c0261
-  PureLayout: f25f0bb904d5ccfe6e31da3cb869185259f02e0d
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
- Removed PureLayout dependency from the Mac App
- @ahageali Replaced `appSecretKey` with `appSecurityPolicy` and `appSecuritySignature`
